### PR TITLE
Handle multiple cookie values

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -238,12 +238,21 @@ where
     fn call(&mut self, mut request: Request<ReqBody>) -> Self::Future {
         let session_layer = self.layer.clone();
 
-        let cookie_value = request
+        let cookie_values = request
             .headers()
             .get(COOKIE)
-            .and_then(|cookie| Cookie::parse_encoded(cookie.to_str().unwrap()).ok())
-            .filter(|cookie| cookie.name() == session_layer.cookie_name)
-            .and_then(|cookie| session_layer.verify_signature(cookie.value()).ok());
+            .map(|cookies| cookies.to_str());
+
+        let cookie_value = if let Some(Ok(cookies)) = cookie_values {
+            cookies
+                .split(";")
+                .map(|cookie| cookie.trim())
+                .filter_map(|cookie| Cookie::parse_encoded(cookie).ok())
+                .filter(|cookie| cookie.name() == session_layer.cookie_name)
+                .find_map(|cookie| self.layer.verify_signature(cookie.value()).ok())
+        } else {
+            None
+        };
 
         let mut inner = self.inner.clone();
         Box::pin(async move {


### PR DESCRIPTION
Fixes: #1

Request cookies - if multiple - are sent separated by ; (semicolon), and they can have arbitrary whitespace around them.
This PR adds the support for handling multiple cookies and finding the one with name `session_layer.cookie_name`.

Based on my (not too exhaustive) testing I'm not sure the style could be improved.