### PR TITLE
Unset client cookies on session destroy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ async-session = "3.0.0"
 futures = "0.3.21"
 tower = "0.4.12"
 http-body = "0.4.5"
+tracing = "0.1"
 
 [dependencies.axum]
 version = "0.5.7"

--- a/src/session.rs
+++ b/src/session.rs
@@ -302,8 +302,8 @@ where
                     }
                     Ok(None) => {}
                     Err(e) => {
-                        *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
                         tracing::error!("Failed to reach session storage: {:?}", e);
+                        *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
                     }
                 }
             }


### PR DESCRIPTION
I think it's reasonable to unset cookies at client side whenever the session is destroyed. (At least actix-sessions [does this.](https://docs.rs/actix-session/latest/actix_session/struct.Session.html#method.purge))

Also, in my opinion it's a much nicer experience to avoid panics, because that causes the response to hang and never arrive. Instead, on storage failure we should send back a 500 INTERNAL_SERVER_ERROR. Also added tracing errors to appropriate places.

Let me know what do you think about these changes.