### PR TITLE
Update axum to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ tower = "0.4.12"
 tracing = "0.1"
 
 [dependencies.axum]
-version = "0.5.7"
+version = "0.6.0-rc.1"
 features = ["headers"]
 
 [dependencies.axum-extra]
-version = "0.3.4"
+version = "0.4.0-rc.1"
 features = ["cookie-signed"]
 
 [dependencies.tokio]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ tower = "0.4.12"
 tracing = "0.1"
 
 [dependencies.axum]
-version = "0.6.0-rc.1"
+version = "0.6.0"
 features = ["headers"]
 
 [dependencies.axum-extra]
-version = "0.4.0-rc.1"
+version = "0.4.0"
 features = ["cookie-signed"]
 
 [dependencies.tokio]

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ async fn main() {
     async fn protected_handler(session: ReadableSession) -> &'static str {
         if session
             .get::<bool>("signed_in")
-            .map_or(false, |signed_in| signed_in)
+            .unwrap_or(false)
         {
             "Shh, it's secret!"
         } else {

--- a/examples/async-sqlx-session/Cargo.toml
+++ b/examples/async-sqlx-session/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = "0.6.0-rc.1"
+axum = "0.6.0"
 axum-sessions = { path = "../../" }
 
 [dependencies.async-sqlx-session]

--- a/examples/async-sqlx-session/Cargo.toml
+++ b/examples/async-sqlx-session/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = "0.5.13"
+axum = "0.6.0-rc.1"
 axum-sessions = { path = "../../" }
 
 [dependencies.async-sqlx-session]

--- a/examples/regenerate/Cargo.toml
+++ b/examples/regenerate/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = "0.6.0-rc.1"
+axum = "0.6.0"
 axum-sessions = { path = "../../" }
 
 [dependencies.rand]

--- a/examples/regenerate/Cargo.toml
+++ b/examples/regenerate/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = "0.5.13"
+axum = "0.6.0-rc.1"
 axum-sessions = { path = "../../" }
 
 [dependencies.rand]

--- a/examples/signin/Cargo.toml
+++ b/examples/signin/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = "0.6.0-rc.1"
+axum = "0.6.0"
 axum-sessions = { path = "../../" }
 
 [dependencies.rand]

--- a/examples/signin/Cargo.toml
+++ b/examples/signin/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = "0.5.13"
+axum = "0.6.0-rc.1"
 axum-sessions = { path = "../../" }
 
 [dependencies.rand]

--- a/examples/signin/src/main.rs
+++ b/examples/signin/src/main.rs
@@ -25,7 +25,7 @@ async fn main() {
     async fn protected_handler(session: ReadableSession) -> &'static str {
         if session
             .get::<bool>("signed_in")
-            .map_or(false, |signed_in| signed_in)
+            .unwrap_or(false)
         {
             "Shh, it's secret!"
         } else {

--- a/examples/signin/src/main.rs
+++ b/examples/signin/src/main.rs
@@ -23,10 +23,7 @@ async fn main() {
     }
 
     async fn protected_handler(session: ReadableSession) -> &'static str {
-        if session
-            .get::<bool>("signed_in")
-            .unwrap_or(false)
-        {
+        if session.get::<bool>("signed_in").unwrap_or(false) {
             "Shh, it's secret!"
         } else {
             "Nothing to see here."

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -1,10 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use axum::{
-    async_trait,
-    extract::{FromRequest, RequestParts},
-    Extension,
-};
+use axum::{async_trait, extract::FromRequestParts, http::request::Parts, Extension};
 use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard};
 
 use crate::SessionHandle;
@@ -25,16 +21,17 @@ impl Deref for ReadableSession {
 }
 
 #[async_trait]
-impl<B> FromRequest<B> for ReadableSession
+impl<S> FromRequestParts<S> for ReadableSession
 where
-    B: Send,
+    S: Send + Sync,
 {
     type Rejection = std::convert::Infallible;
 
-    async fn from_request(request: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
-        let Extension(session_handle): Extension<SessionHandle> = Extension::from_request(request)
-            .await
-            .expect("Session extension missing. Is the session layer installed?");
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let Extension(session_handle): Extension<SessionHandle> =
+            Extension::from_request_parts(parts, state)
+                .await
+                .expect("Session extension missing. Is the session layer installed?");
         let session = session_handle.read_owned().await;
 
         Ok(Self { session })
@@ -63,16 +60,17 @@ impl DerefMut for WritableSession {
 }
 
 #[async_trait]
-impl<B> FromRequest<B> for WritableSession
+impl<S> FromRequestParts<S> for WritableSession
 where
-    B: Send,
+    S: Send + Sync,
 {
     type Rejection = std::convert::Infallible;
 
-    async fn from_request(request: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
-        let Extension(session_handle): Extension<SessionHandle> = Extension::from_request(request)
-            .await
-            .expect("Session extension missing. Is the session layer installed?");
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let Extension(session_handle): Extension<SessionHandle> =
+            Extension::from_request_parts(parts, state)
+                .await
+                .expect("Session extension missing. Is the session layer installed?");
         let session = session_handle.write_owned().await;
 
         Ok(Self { session })


### PR DESCRIPTION
Axum `0.6.0-rc.1` just [came out](https://github.com/tokio-rs/axum/releases), and it has some breaking changes that affect axum-sessions too. 

Obviously this PR needs to wait for the stable version before merging (and TODO: update versions in `Cargo.toml` after that). Sorry for rushing, but I'm already testing the 0.6.0-rc.1, and if I've already put together these changes for axum-sessions: why not make a PR? :grin: 