### PR TITLE
Do not store cookie if not required

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-sessions"
-version = "0.3.2"
+version = "0.4.0"
 description = "🥠 Cookie-based sessions for Axum via async-session."
 edition = "2021"
 homepage = "https://github.com/maxcountryman/axum-sessions"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,9 @@
 //!
 //! ```rust,no_run
 //! use axum::{routing::get, Router};
-//! use axum_sessions::{async_session::MemoryStore, extractors::WritableSession, PersistencePolicy, SessionLayer};
+//! use axum_sessions::{
+//!     async_session::MemoryStore, extractors::WritableSession, PersistencePolicy, SessionLayer,
+//! };
 //!
 //! #[tokio::main]
 //! async fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ```rust,no_run
 //! use axum::{routing::get, Router};
-//! use axum_sessions::{async_session::MemoryStore, extractors::WritableSession, SessionLayer};
+//! use axum_sessions::{async_session::MemoryStore, extractors::WritableSession, PersistencePolicy, SessionLayer};
 //!
 //! #[tokio::main]
 //! async fn main() {
@@ -98,4 +98,4 @@ mod session;
 pub use async_session;
 pub use axum_extra::extract::cookie::SameSite;
 
-pub use self::session::{Session, SessionHandle, SessionLayer};
+pub use self::session::{PersistencePolicy, Session, SessionHandle, SessionLayer};

--- a/src/session.rs
+++ b/src/session.rs
@@ -46,7 +46,8 @@ pub enum PersistencePolicy {
     /// Do not store empty "guest" sessions, only ping the storage layer if
     /// the session data changed.
     ChangedOnly,
-    /// Do not store empty "guest" sessions, always ping the storage layer for existing sessions.
+    /// Do not store empty "guest" sessions, always ping the storage layer for
+    /// existing sessions.
     ExistingOnly,
 }
 
@@ -71,7 +72,8 @@ impl<Store: SessionStore> SessionLayer<Store> {
     /// hydrated from this. Otherwise a new cookie is created and returned in
     /// the response.
     ///
-    /// The default behaviour is to enable "guest" sessions with [`SessionPolicy::Always`].
+    /// The default behaviour is to enable "guest" sessions with
+    /// [`PersistencePolicy::Always`].
     ///
     /// # Panics
     ///
@@ -350,8 +352,10 @@ where
 
             // Store if
             //  - We have guest sessions
-            //  - We received a valid cookie and we use the `ExistingOnly` policy.
-            //  - If we use the `ChangedOnly` policy, only `session.data_changed()` should trigger this branch.
+            //  - We received a valid cookie and we use the `ExistingOnly`
+            //    policy.
+            //  - If we use the `ChangedOnly` policy, only
+            //    `session.data_changed()` should trigger this branch.
             } else if session_layer.should_store(&cookie_value, session_data_changed) {
                 match session_layer.store.store_session(session).await {
                     Ok(Some(cookie_value)) => {
@@ -391,9 +395,8 @@ mod tests {
     use rand::Rng;
     use tower::{BoxError, Service, ServiceBuilder, ServiceExt};
 
-    use crate::{async_session::MemoryStore, SessionHandle, SessionLayer};
-
     use super::PersistencePolicy;
+    use crate::{async_session::MemoryStore, SessionHandle, SessionLayer};
 
     #[derive(Deserialize, Serialize, PartialEq, Debug)]
     struct Counter {
@@ -552,10 +555,9 @@ mod tests {
         let store = MemoryStore::new();
         let session_layer =
             SessionLayer::new(store, &secret).with_persistence_policy(persistence_policy);
-        let mut service =
-            ServiceBuilder::new()
-                .layer(&session_layer)
-                .service_fn(echo_read_session);
+        let mut service = ServiceBuilder::new()
+            .layer(&session_layer)
+            .service_fn(echo_read_session);
 
         let request = Request::get("/").body(Body::empty()).unwrap();
 


### PR DESCRIPTION
The session must not store a cookie if there is no need to.

The current implementation always creates a new session cookie on the client, even when the session is empty. The behaviour should be:

* No session cookie in request, no data in session? Do not send a cookie response header
* An invalid/expired session cookie is present in request header? Sent a cookie response header for a fresh session.